### PR TITLE
Disable react/no-unescaped-entities

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
     'react/forbid-component-props' : 'off',
     'react/no-danger'              : 'off',
     'react/no-string-refs'         : 'off',
+    'react/no-unescaped-entities'  : 'off',
     'react/sort-comp'              : ['error', {
       order : [
         'static',


### PR DESCRIPTION
[This fix](https://stackoverflow.com/questions/43177074/how-to-fix-this-violation-of-this-react-no-unescaped-entitie-of-eslint-rule) does not make sense.