### PR TITLE
off jsx-a11y/label-fas-for

### DIFF
--- a/jsx-a11y.js
+++ b/jsx-a11y.js
@@ -6,10 +6,6 @@ module.exports = {
     'plugin:jsx-a11y/recommended'
   ],
   rules : {
-    'jsx-a11y/label-has-for' : [2, {
-      required : {
-        some : ['nesting', 'id']
-      }
-    }]
+    'jsx-a11y/label-has-for' : 'off' // [Deprecated on eslint-plugin-jsx-a11y v6.1.0]
   }
 };


### PR DESCRIPTION
this rule was deprecated on eslint-plugin-jsx-a11y v6.1.0

- https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
- https://github.com/evcohen/eslint-plugin-jsx-a11y/releases/tag/v6.1.0